### PR TITLE
feat: improved Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,15 @@ RUN lein uberjar
 
 # -----------------------------------------------------------------------------
 
-from openjdk:11
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN groupadd -r commentator && useradd -r -s /bin/false -g commentator commentator
+RUN addgroup -S commentator && \
+    adduser -s /bin/false -G commentator -S commentator && \
+    apk add --update-cache git && \ 
+    rm -rf /var/cache/apk/*
 RUN mkdir /app
-COPY --from=build-env /app/target/uberjar/commentator-*-standalone.jar /app/commentator.jar
-
-RUN chown -R commentator:commentator /app
-
-RUN apt-get update && apt-get -y upgrade && apt-get install -y git
-user commentator
+COPY --from=build-env --chown=commentator:commentator /app/target/uberjar/commentator-*-standalone.jar /app/commentator.jar
+USER commentator
 
 ENTRYPOINT ["java"]
-
 CMD ["-jar", "/app/commentator.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN lein uberjar
 FROM adoptopenjdk/openjdk11:alpine-jre
 
 RUN addgroup -S commentator && \
-    adduser -s /bin/false -G commentator -S commentator && \
-    apk add --update-cache git && \ 
-    rm -rf /var/cache/apk/*
+    adduser -s /bin/false -G commentator -S commentator
+    
 RUN mkdir /app
 COPY --from=build-env --chown=commentator:commentator /app/target/uberjar/commentator-*-standalone.jar /app/commentator.jar
 USER commentator


### PR DESCRIPTION
## Why?
The proposed Docker image is containing commands which are making the image bigger than normal. This will cause problems in cloud installation causing a slow startup and diskspace consumption (especially during a new rollout).
![image](https://user-images.githubusercontent.com/139323/107188746-7d45fd00-69e8-11eb-9bea-3a173647212d.png)
An example in this image. The `chown` command is creating a completely new layer, with the **same size as the original one** with exactly the same files changing only the ownership.

## What?
A new Dockerfile with some best practices applied and a base image adapted for production.
* No `chown`
* Clean cache after package install (apt-get or apk)
* Prevent `upgrade`. We need to use exactly the base image, or use a newver version of the base image to have fresh packages

The result in size is the following:
![image](https://user-images.githubusercontent.com/139323/107188965-d9a91c80-69e8-11eb-9683-9c90f7192188.png)
